### PR TITLE
Fix broken link and add lab environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ http://www.kubernet.io/ (Currently offline)
 
 https://github.com/kelseyhightower/kubernetes-the-hard-way
 
-https://linuxacademy.com
+https://acloudguru.com/course/certified-kubernetes-administrator-cka
 
 https://kubernetes.io/docs/
 
@@ -24,6 +24,8 @@ https://kubernetes.io/docs/tasks/
 ### Lab Environments
 
 https://kubernetes.io/docs/setup/learning-environment/minikube/
+
+https://kubernetes.io/blog/2020/05/21/wsl-docker-kubernetes-on-the-windows-desktop/
 
 ### Contact
 


### PR DESCRIPTION
- Fix broken link - LinuxAcademy is now part of [ACG ](https://acloudguru.com/blog/news/an-update-on-how-were-creating-new-acg-content)
- Add WSL with Docker setup for a lab environment